### PR TITLE
optional authentication and geocoder urls

### DIFF
--- a/browser/arcgis.js
+++ b/browser/arcgis.js
@@ -33,6 +33,10 @@ function stringify (obj) {
 function authenticate (username, password, options, callback) {
   var url = "https://www.arcgis.com/sharing/generateToken";
 
+  if (this.options && this.options.authenticationUrl) {
+    url = this.options.authenticationUrl;
+  }
+
   var data = {
     username: username,
     password: password,
@@ -188,11 +192,23 @@ FeatureService.prototype.edit = function (parameters, callback) {
   issueRequest('applyEdits', parameters, callback, 'post');
 };
 
+function baseUrl(options) {
+  var url = 'http://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer';
+
+  if (options && options.geocoderUrl) {
+    url = options.geocoderUrl;
+  }
+
+  return url;
+}
+
 function geocode (parameters, callback) {
   parameters.f = parameters.f || "json";
 
   // build the request url
-  var url = 'http://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/find?';
+  var url = baseUrl(this.options);
+  url += '/find?';
+
   url += stringify(parameters);
 
   this.requestHandler.get(url, callback);
@@ -202,7 +218,9 @@ function reverse (parameters, callback) {
   parameters.f = parameters.f || "json";
 
   // build the request url
-  var url = 'http://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/reverseGeocode?';
+  var url = baseUrl(this.options);
+
+  url += '/reverseGeocode?';
   url += stringify(parameters);
 
   this.requestHandler.get(url, callback);
@@ -214,7 +232,9 @@ function addresses (parameters, callback) {
   }
 
   //build the request url
-  var url = 'http://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/findAddressCandidates?';
+  var url = baseUrl(this.options);
+
+  url += '/findAddressCandidates?';
 
   //allow a text query like simple geocode service to return all candidate addresses
   if (parameters.text) {
@@ -281,7 +301,11 @@ Batch.prototype.run = function (callback) {
       referer: "arcgis-node"
     };
 
-    this.requestHandler.post("http://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/geocodeAddresses", data, callback);
+    var url = baseUrl(this.options);
+
+    url += "/geocodeAddresses";  
+
+    this.requestHandler.post(url, data, callback);
   }
 };
 
@@ -307,7 +331,7 @@ function get (url, callback) {
   httpRequest.open("GET", url);
   if (httpRequest.setDisableHeaderCheck !== undefined) {
     httpRequest.setDisableHeaderCheck(true);
-    httpRequest.setRequestHeader("Referer", "arcgis-node");
+    httpRequest.setRequestHeader("Referer", "geoservices-js");
   }
   httpRequest.send(null);
 }
@@ -333,7 +357,7 @@ function post (url, data, callback) {
   httpRequest.open("POST", url);
   if (httpRequest.setDisableHeaderCheck !== undefined) {
     httpRequest.setDisableHeaderCheck(true);
-    httpRequest.setRequestHeader("Referer", "arcgis-node");
+    httpRequest.setRequestHeader("Referer", "geoservices-js");
   }
   
   httpRequest.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");

--- a/lib/authentication.js
+++ b/lib/authentication.js
@@ -1,6 +1,10 @@
 function authenticate (username, password, options, callback) {
   var url = "https://www.arcgis.com/sharing/generateToken";
 
+  if (this.options && this.options.authenticationUrl) {
+    url = this.options.authenticationUrl;
+  }
+
   var data = {
     username: username,
     password: password,

--- a/lib/geocode.js
+++ b/lib/geocode.js
@@ -2,11 +2,23 @@ var querystring = require('querystring');
 
 var stringify = querystring.stringify;
 
+function baseUrl(options) {
+  var url = 'http://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer';
+
+  if (options && options.geocoderUrl) {
+    url = options.geocoderUrl;
+  }
+
+  return url;
+}
+
 function geocode (parameters, callback) {
   parameters.f = parameters.f || "json";
 
   // build the request url
-  var url = 'http://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/find?';
+  var url = baseUrl(this.options);
+  url += '/find?';
+
   url += stringify(parameters);
 
   this.requestHandler.get(url, callback);
@@ -16,7 +28,9 @@ function reverse (parameters, callback) {
   parameters.f = parameters.f || "json";
 
   // build the request url
-  var url = 'http://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/reverseGeocode?';
+  var url = baseUrl(this.options);
+
+  url += '/reverseGeocode?';
   url += stringify(parameters);
 
   this.requestHandler.get(url, callback);
@@ -28,7 +42,9 @@ function addresses (parameters, callback) {
   }
 
   //build the request url
-  var url = 'http://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/findAddressCandidates?';
+  var url = baseUrl(this.options);
+
+  url += '/findAddressCandidates?';
 
   //allow a text query like simple geocode service to return all candidate addresses
   if (parameters.text) {
@@ -95,7 +111,11 @@ Batch.prototype.run = function (callback) {
       referer: "arcgis-node"
     };
 
-    this.requestHandler.post("http://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/geocodeAddresses", data, callback);
+    var url = baseUrl(this.options);
+
+    url += "/geocodeAddresses";  
+
+    this.requestHandler.post(url, data, callback);
   }
 };
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -26,7 +26,7 @@ function get (url, callback) {
   httpRequest.open("GET", url);
   if (httpRequest.setDisableHeaderCheck !== undefined) {
     httpRequest.setDisableHeaderCheck(true);
-    httpRequest.setRequestHeader("Referer", "arcgis-node");
+    httpRequest.setRequestHeader("Referer", "geoservices-js");
   }
   httpRequest.send(null);
 }
@@ -52,7 +52,7 @@ function post (url, data, callback) {
   httpRequest.open("POST", url);
   if (httpRequest.setDisableHeaderCheck !== undefined) {
     httpRequest.setDisableHeaderCheck(true);
-    httpRequest.setRequestHeader("Referer", "arcgis-node");
+    httpRequest.setRequestHeader("Referer", "geoservices-js");
   }
   
   httpRequest.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");

--- a/src/authentication.js
+++ b/src/authentication.js
@@ -1,6 +1,10 @@
 function authenticate (username, password, options, callback) {
   var url = "https://www.arcgis.com/sharing/generateToken";
 
+  if (this.options && this.options.authenticationUrl) {
+    url = this.options.authenticationUrl;
+  }
+
   var data = {
     username: username,
     password: password,

--- a/src/geocode.js
+++ b/src/geocode.js
@@ -1,8 +1,20 @@
+function baseUrl(options) {
+  var url = 'http://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer';
+
+  if (options && options.geocoderUrl) {
+    url = options.geocoderUrl;
+  }
+
+  return url;
+}
+
 function geocode (parameters, callback) {
   parameters.f = parameters.f || "json";
 
   // build the request url
-  var url = 'http://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/find?';
+  var url = baseUrl(this.options);
+  url += '/find?';
+
   url += stringify(parameters);
 
   this.requestHandler.get(url, callback);
@@ -12,7 +24,9 @@ function reverse (parameters, callback) {
   parameters.f = parameters.f || "json";
 
   // build the request url
-  var url = 'http://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/reverseGeocode?';
+  var url = baseUrl(this.options);
+
+  url += '/reverseGeocode?';
   url += stringify(parameters);
 
   this.requestHandler.get(url, callback);
@@ -24,7 +38,9 @@ function addresses (parameters, callback) {
   }
 
   //build the request url
-  var url = 'http://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/findAddressCandidates?';
+  var url = baseUrl(this.options);
+
+  url += '/findAddressCandidates?';
 
   //allow a text query like simple geocode service to return all candidate addresses
   if (parameters.text) {
@@ -91,6 +107,10 @@ Batch.prototype.run = function (callback) {
       referer: "arcgis-node"
     };
 
-    this.requestHandler.post("http://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/geocodeAddresses", data, callback);
+    var url = baseUrl(this.options);
+
+    url += "/geocodeAddresses";  
+
+    this.requestHandler.post(url, data, callback);
   }
 };

--- a/src/request.js
+++ b/src/request.js
@@ -20,7 +20,7 @@ function get (url, callback) {
   httpRequest.open("GET", url);
   if (httpRequest.setDisableHeaderCheck !== undefined) {
     httpRequest.setDisableHeaderCheck(true);
-    httpRequest.setRequestHeader("Referer", "arcgis-node");
+    httpRequest.setRequestHeader("Referer", "geoservices-js");
   }
   httpRequest.send(null);
 }
@@ -46,7 +46,7 @@ function post (url, data, callback) {
   httpRequest.open("POST", url);
   if (httpRequest.setDisableHeaderCheck !== undefined) {
     httpRequest.setDisableHeaderCheck(true);
-    httpRequest.setRequestHeader("Referer", "arcgis-node");
+    httpRequest.setRequestHeader("Referer", "geoservices-js");
   }
   
   httpRequest.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");


### PR DESCRIPTION
This change allows for `authenticationUrl` and `geocoderUrl` to be passed in as part of `options` at instantiation to be used for authentication and geocoding.

This should allow for more generic geoservices use.
