### PR TITLE
proper fix for reverse geocoding

### DIFF
--- a/browser/arcgis.js
+++ b/browser/arcgis.js
@@ -338,6 +338,9 @@ Batch.prototype.run = function (callback) {
   }
 };
 
+geocode.simple  = geocode;
+geocode.reverse = reverse;
+geocode.addresses = addresses;
 
 function get (url, callback) {
   var httpRequest = new XMLHttpRequest();
@@ -398,7 +401,6 @@ function ArcGIS (options) {
   this.options = options;
 
   this.geocode = geocode;
-  this.geocode.reverse = reverse;
   this.FeatureService = FeatureService;
   this.authenticate   = authenticate;
   this.requestHandler = { get: get, post: post };

--- a/src/geocode.js
+++ b/src/geocode.js
@@ -131,3 +131,7 @@ Batch.prototype.run = function (callback) {
     this.requestHandler.post(url, data, callback);
   }
 };
+
+geocode.simple  = geocode;
+geocode.reverse = reverse;
+geocode.addresses = addresses;

--- a/src/partials/browser/tail.js
+++ b/src/partials/browser/tail.js
@@ -2,7 +2,6 @@ function ArcGIS (options) {
   this.options = options;
 
   this.geocode = geocode;
-  this.geocode.reverse = reverse;
   this.FeatureService = FeatureService;
   this.authenticate   = authenticate;
   this.requestHandler = { get: get, post: post };

--- a/src/partials/node/geocode-tail.js
+++ b/src/partials/node/geocode-tail.js
@@ -1,5 +1,2 @@
-geocode.simple  = geocode;
-geocode.reverse = reverse;
-geocode.addresses = addresses;
 exports.Batch   = Batch;
 exports.geocode = geocode;


### PR DESCRIPTION
also adds in `addresses` and `simple`.

the `geocode` sub methods had been moved to the node tail, and not did not survive to the browser build.  this moves them back as well as undoing @patrickarlt's change this morning.
