### PR TITLE
added option to specify referer in options passed to authenticate function

### DIFF
--- a/src/authentication.js
+++ b/src/authentication.js
@@ -23,8 +23,13 @@ function authenticate (username, password, options, callback) {
     referer:  "arcgis-node"
   };
 
-  if (options && options.expiration) {
-    data.expiration = options.expiration;
+  if (options) {
+    if (options.expiration){
+      data.expiration = options.expiration;
+    }
+    if (options.referer){
+      data.referer = options.referer;
+    }
   }
 
   var self = this;


### PR DESCRIPTION
I ran into problems calling a feature service query against a non-public feature service.  I have a feature service hosted on ArcGIS Online that is shared only with my organization. From a web application, if I use geoservices-js authenticate to get a token and then use the token in a call to geoservices-js featureservice.query, an invalid token error is thrown.  Removing the hard-coded referer parameter of "arcgis-node" and setting the referer parameter of the authenticate request to match the host of the web application fixed the problem.  So I think allowing a client to specify the referer is needed.     
