### PR TITLE
Sync docs in README.md and Getting Started.md, and link to further documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,19 @@
 # Geoservices-js
 
-Javascript bindings for Geoservices.  For more information see the Geoservices Specification available at http://www.esri.com/library/whitepapers/pdfs/geoservices-rest-spec.pdf
+Javascript bindings for Geoservices.
+ 
+This module exposes both authenticated and non-authenticated aspects of Geoservices such as [ArcGIS Online](http://www.arcgis.com/).
+
+## Non-authenticated Services
+
+* Geocoding
+* Reverse Geocoding
+* Addresses
+* Feature Services
+
+## Authenticated Services
+
+* Bulk Geocoding
 
 ## Usage
 
@@ -13,10 +26,15 @@ Javascript bindings for Geoservices.  For more information see the Geoservices S
 
 ### Node.js
 
-    var Geoservices = require('geoservices');
-    
-    var client = new Geoservices();
+#### Installing
 
+    $ npm install geoservices
+
+#### Basic Usage
+
+    var Geoservices = require('geoservices');
+
+    var client = new Geoservices();
 
 ## Building
 
@@ -33,6 +51,13 @@ To build and run tests, simply run:
 Testing can also occur stand-alone:
 
     $ npm test
+
+## Further documentation
+
+* [Feature Services](docs/FeatureServices.md) are the primary way of accessing vector features from Esri services, and are very deep in terms on functionality.
+* [Geocoding](docs/Geocoding.md) documents how to do simple geocoding, reverse geocoding and batch geocoding.
+
+For more information see the Geoservices Specification available at http://www.esri.com/library/whitepapers/pdfs/geoservices-rest-spec.pdf
 
 ## Contributing
 

--- a/docs/Getting Started.md
+++ b/docs/Getting Started.md
@@ -31,3 +31,16 @@ This module exposes both authenticated and non-authenticated aspects of Geoservi
     var Geoservices = require('geoservices');
     
     var client = new Geoservices();
+
+## Further documentation
+
+* [Feature Services](FeatureServices.md) are the primary way of accessing vector features from Esri services, and are very deep in terms on functionality.
+* [Geocoding](Geocoding.md) documents how to do simple geocoding, reverse geocoding and batch geocoding.
+
+For more information see the Geoservices Specification available at http://www.esri.com/library/whitepapers/pdfs/geoservices-rest-spec.pdf
+
+## Contributing
+
+Esri welcomes contributions from anyone and everyone. Please see our [guidelines for contributing](https://github.com/esri/contributing).
+
+This is an open library for communicating with any service that implements the Geoservices specification.  The default endpoint for Geocoding is ArcGIS Online.  Please see [Terms of Use](http://resources.arcgis.com/en/help/arcgis-rest-api/#/ArcGIS_Online_services_licensing/02r3000001mv000000/) for licensing and usage details.


### PR DESCRIPTION
```
README and Getting Started were similar docs, but contained some
differences.

This patch largely syncs the docs between them.

Also, neither document was linking to the two additional docs/
directory. Now both docs links to the additional documentation.
```
