### PR TITLE
BugFix: When the JSON parsing of the auth response fails, the callback was reporting success.

### DIFF
--- a/lib/authentication.js
+++ b/lib/authentication.js
@@ -44,8 +44,8 @@ function authenticate (username, password, options, callback) {
       try {
         token = JSON.parse(data);
         self.token = token;
-      } catch (error) {
-        callback(err, token);
+      } catch (jsonParseError) {
+        callback("Error parsing JSON in authentication response: "+jsonParseError, token);
         return;
       }
     }

--- a/test/authentication-test.js
+++ b/test/authentication-test.js
@@ -51,5 +51,19 @@ vows.describe('Authentication').addBatch({
       assert.equal(err, null);
       assert.equal(data.error.code, 400);
     }
-  }
+  },
+  'When invalid JSON is returned': {
+      topic: function () {
+        // mock request tu return bad JSON
+        var requestHandler = {
+          post: function (url, data, callback) {
+            callback(null, null, 'NOT VALID JSON');
+          }
+        };
+        authentication.authenticate('foo', 'bar', { requestHandler: requestHandler }, this.callback);
+      },
+      'it should return an error': function (err, data) {
+        assert.equal(err, 'Error parsing JSON in authentication response: SyntaxError: Unexpected token N');
+      }
+    }
 }).export(module);


### PR DESCRIPTION
The issue was that the callback was returning the 'err' from the outer 
function in this case, which was `null`, rather than `error' from catch, which
contained the JSON parsing error.

In addition to fixing the bug, I used a more distinct variable name for the
JSON parsing error to avoid confusion, and clearly labeled the issue as a JSON
parsing error in the returned diagnostic.

Test coverage for the issue is included.
