### PR TITLE
Fix #62 again. Use SSL for geocoding calls. It's better for security and

### DIFF
--- a/lib/geocode.js
+++ b/lib/geocode.js
@@ -10,7 +10,7 @@ var stringify = querystring.stringify;
  * @private
 */
 function baseUrl(options) {
-  var url = 'http://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer';
+  var url = 'https://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer';
 
   if (options && options.geocoderUrl) {
     url = options.geocoderUrl;


### PR DESCRIPTION
privacy, and also fixes things organizations set to SSL only.
