### PR TITLE
Fix authentication.

### DIFF
--- a/lib/authentication.js
+++ b/lib/authentication.js
@@ -56,7 +56,7 @@ function authenticate (username, password, options, callback) {
   if (options.requestHandler) {
     options.requestHandler.post(url, data, internalCallback);
   } else {
-    request.post(url, internalCallback).form(data);
+    request.post({url:url,form:data}, internalCallback);
   }
 }
 


### PR DESCRIPTION
After grading from the pre-node-specific version, authentication broke for me. 
I traced it to this issue.

I think the old syntax used for 'request' may have not have been valid. While
I see in the `request` docs the use of `.form`, I don't see it documented in
combination with the callback.

In any case, the syntax for calling `request` works now.

Note that the expected args pasted to `request.host` and the undocumented
`requestHandler` were not the same before, and they remain different after
this change. I would expect the `requestHander` should accept the same
arguments as `request` but am not changing it here in case someone is using
this undocumented feature outside of the test suite. That should potentially
be updated as well for consistency.

Also, while looking at `request`, you may wish to bump the dependency up to
2.39.0 in package.json.
