### PR TITLE
Fix error with Edits and JSON parse error handling.

### DIFF
--- a/lib/featureservice.js
+++ b/lib/featureservice.js
@@ -73,8 +73,10 @@ FeatureService.prototype.get = function () {
 function _internalCallback(err, data, cb){
   try {
     data = JSON.parse(data);
-  } catch (error) {
-    cb(err);
+  } catch (jsonParseError) {
+    if (cb) {
+      cb('Error parsing JSON in Feature Service response: ' + jsonParseError, data);
+    }
     return;
   }
 


### PR DESCRIPTION
If the string result could not be JSON parsed, the callback would not get called correctly.

Also, edit was not getting called correctly.
