### PR TITLE
Remove the dead _requestHandler function.

### DIFF
--- a/lib/featureservice.js
+++ b/lib/featureservice.js
@@ -1,28 +1,6 @@
 var querystring = require('querystring');
 var request = require('request');
 
-var stringify = querystring.stringify;
-
-
-function _requestHandler (callback) {
-  return function () {
-    if (this.readyState === this.DONE) {
-      if (this.status === 200) {
-        var returnErr = null;
-        var response;
-        try {
-          response = JSON.parse(this.responseText);
-        } catch (err) {
-          returnErr = "Invalid JSON on response: " + this.responseText;
-        }
-
-        // Handle both success and failure in one callback
-        callback(returnErr, response);
-      }
-    }
-  };
-}
-
 function FeatureService (options, callback) {
   this.lastQuery = null;
   this.url       = null;
@@ -104,7 +82,7 @@ FeatureService.prototype.issueRequest = function (endPoint, parameters, cb, meth
   var url = this.url + urlPart;
 
   if (!method || method.toLowerCase() === "get") {
-    url = url + '?' + stringify(parameters);
+    url = url + '?' + querystring.stringify(parameters);
 
     request.get(url, function (err, req, data) {
       _internalCallback(err, data, cb);


### PR DESCRIPTION
This was first spotted by @nixta. This is just a smaller, simpler pull request
to review and merge.

Also, the stringify variable was only used in one place so I inlined the 
single use of it to simplify things a bit.
