### PR TITLE
Remove unused _requestHandler function.

### DIFF
--- a/lib/featureservice.js
+++ b/lib/featureservice.js
@@ -1,23 +1,5 @@
-var querystring = require('querystring');
-var request = require('request');
-
-var stringify = querystring.stringify;
-
-
-function _requestHandler (callback) {
-  return function () {
-    if (this.readyState === this.DONE) {
-      if (this.status === 200) {
-        try {
-          var response = JSON.parse(this.responseText);
-          callback(null, response);
-        } catch (err) {
-          callback("Invalid JSON on response: " + this.responseText);
-        }
-      }
-    }
-  };
-}
+var querystring = require('querystring'),
+    request = require('request');
 
 function FeatureService (options, callback) {
   this.lastQuery = null;
@@ -102,7 +84,7 @@ FeatureService.prototype.issueRequest = function (endPoint, parameters, cb, meth
   var url = this.url + urlPart;
 
   if (!method || method.toLowerCase() === "get") {
-    url = url + '?' + stringify(parameters);
+    url = url + '?' + querystring.stringify(parameters);
 
     request.get(url, function (err, req, data) {
       _internalCallback(err, data, cb);


### PR DESCRIPTION
A redo of PR #81, since PR #80 broke that, including inlining the querystring stringify (as per @markstos's suggestion).
