### PR TITLE
check for OBJECTID in address objects

### DIFF
--- a/lib/geocode.js
+++ b/lib/geocode.js
@@ -128,7 +128,7 @@ Batch.prototype.geocode = function (record, optionalId) {
   }
 
   if (typeof record === 'object') {
-    if (!record.OBJECTID && record.OBJECTID !== 0) {
+    if (record.hasOwnProperty('OBJECTID') && record.OBJECTID != 0) {
       record.OBJECTID = optionalId;
     }
   } else if (typeof record === 'string') {

--- a/lib/geocode.js
+++ b/lib/geocode.js
@@ -128,7 +128,9 @@ Batch.prototype.geocode = function (record, optionalId) {
   }
 
   if (typeof record === 'object') {
-    record.OBJECTID = optionalId;
+    if (!record.OBJECTID && record.OBJECTID !== 0) {
+      record.OBJECTID = optionalId;
+    }
   } else if (typeof record === 'string') {
     record = {
       "SingleLine": record,


### PR DESCRIPTION
closes #90.  now you can supply an objectid two different ways:
```javascript
batch.geocode({
  singleLine: "224 N. College Ave, Bloomington, Indiana"//,
  OBJECTID: 1234
});

// or

batch.geocode("224 N. College Ave, Bloomington, Indiana", 1234);
```
thanks for the catch @wilsaj 