### PR TITLE
Make the `new` constructor keyword optional for featureservice

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 sudo: false
 node_js:
-  - "0.12"
+  - "node"
 cache:
   directories:
     - node_modules

--- a/lib/featureservice.js
+++ b/lib/featureservice.js
@@ -2,6 +2,7 @@ var querystring = require('querystring'),
     request = require('request');
 
 function FeatureService (options, callback) {
+  if (!(this instanceof FeatureService)) return new FeatureService(options, callback)
   this.lastQuery = null;
   this.url       = null;
   this.options   = options;

--- a/test/authentication-test.js
+++ b/test/authentication-test.js
@@ -22,7 +22,7 @@ vows.describe('Authentication').addBatch({
   },
   'When authenticating with a valid account and expiration': {
     topic: function () {
-      // mock 
+      // mock
       var requestHandler = {
         post: function (url, data, callback) {
           callback(null, null, JSON.stringify({ token: 'abc123', expires: 1366662062704, ssl: false }));
@@ -38,7 +38,7 @@ vows.describe('Authentication').addBatch({
   },
   'When authenticating with an invalid account': {
     topic: function () {
-      // mock 
+      // mock
       var requestHandler = {
         post: function (url, data, callback) {
           callback(null, null, JSON.stringify({ error: { code: 400, message: 'Unable to generate token.', details: [ 'Invalid username or password.' ] } }));
@@ -63,7 +63,7 @@ vows.describe('Authentication').addBatch({
         authentication.authenticate('foo', 'bar', { requestHandler: requestHandler }, this.callback);
       },
       'it should return an error': function (err, data) {
-        assert.equal(err, 'Error parsing JSON in authentication response: SyntaxError: Unexpected token N');
+        assert.equal(err, 'Error parsing JSON in authentication response: SyntaxError: Unexpected token N in JSON at position 0');
       }
     }
 }).export(module);

--- a/test/featureservice-test.js
+++ b/test/featureservice-test.js
@@ -22,6 +22,15 @@ vows.describe('FeatureService').addBatch({
       //assert.equal(data.layers[0].name, 'hospitals');
     }
   },
+  'When requesting a featureservice without the new constructor': {
+    topic: function () {
+      featureservice.FeatureService( params , this.callback);
+    },
+    'It should create the service and return the correct service metadata': function (err, data) {
+      assert.equal(err, null)
+      assert.notEqual(data, null)
+    }
+  },
   'When requesting a featureservice by url': {
     topic: function () {
       new featureservice.FeatureService({

--- a/test/featureservice-test.js
+++ b/test/featureservice-test.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 var featureservice = require('../lib/featureservice');
 
 var params = {
-  catalog: 'http://sampleserver6.arcgisonline.com/arcgis/rest/services',
+  catalog: 'https://sampleserver6.arcgisonline.com/arcgis/rest/services',
   service: 'Census',
   type: 'MapServer',
   layer: 3
@@ -25,7 +25,7 @@ vows.describe('FeatureService').addBatch({
   'When requesting a featureservice by url': {
     topic: function () {
       new featureservice.FeatureService({
-        url: 'http://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer/3'
+        url: 'https://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer/3'
       } , this.callback);
     },
     'It should return the correct service metadata': function (err, data) {
@@ -79,7 +79,7 @@ vows.describe('FeatureService').addBatch({
 
 
 var writeParams = {
-  url: 'http://services.arcgis.com/OfH668nDRN7tbJh0/arcgis/rest/services/TDD/FeatureServer/0'
+  url: 'https://services.arcgis.com/OfH668nDRN7tbJh0/arcgis/rest/services/TDD/FeatureServer/0'
 };
 
 var templateRecord = {


### PR DESCRIPTION
Fixes #101. This is a common fall back for constructing a module
without requiring the `new` constructor