### PR TITLE
use findAddressCandidates consistently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## [Upcoming changes][Unreleased]
 
+### Breaking Changes
+
+* As per the recommendation of the Geocoding team, the `/find?` operation is no longer utilized.  Using `/findAddressCandidates?` exclusively has allowed us to simplify this API by removing the `addresses()` method entirely, but necessitates the following changes.
+
+1. the response signature of `geocode()` now provides an array of candidates, not locations.
+2. `singleLine` is now the appropriate parameter to use when supplying a single string to be located.
+
+```js
+client.geocode({ singleLine: "voodoo doughnuts" }, function (err, result) {
+    console.log(result.candidates[0]); //
+  }
+});
+```
+
 ## [1.1.1]
 
 ### Added
@@ -23,7 +37,7 @@
 
 ## 1.0.0
 
-#### Breaking Changes
+### Breaking Changes
 
 * FeatureService calls now automatically detect JSON being passed in and no longer require coersion to `String`
 

--- a/README.md
+++ b/README.md
@@ -4,52 +4,61 @@
 
 Node.js bindings for Geoservices.
 
-This module exposes both authenticated and non-authenticated aspects of Geoservices such as [ArcGIS Online](http://www.arcgis.com/).
+This module abstracts making both authenticated and anonymous common [Geoservices](http://geoservices.github.io/) requests and parsing their response.
 
-## Non-authenticated Services
+## Anonymously accessible services
 
 * Geocoding
 * Reverse Geocoding
 * Addresses
 * Feature Services
 
-## Authenticated Services
+## Services that require authentication
 
 * Bulk Geocoding
 
 ## Usage
 
-
 #### Installing
 
-    $ npm install geoservices
+```
+$ npm install geoservices
+```
 
 #### Basic Usage
 
-    var Geoservices = require('geoservices');
+```js
+var Geoservices = require('geoservices');
 
-    var client = new Geoservices();
+var client = new Geoservices();
+```
 
 ## Building
 
 Geoservices uses `grunt` for its build system.  To install:
 
-    $ sudo npm install -g grunt-cli
+```
+$ sudo npm install -g grunt-cli
+```
 
 To build and run tests, simply run:
 
-    $ grunt
+```
+$ grunt
+```
 
 ## Testing
 
-Testing can also occur stand-alone:
+Standalone testing can also be run:
 
-    $ npm test
+```
+$ npm test
+```
 
 ## Further documentation
 
-* [Feature Services](docs/FeatureServices.md) are the primary way of accessing vector features from Esri services, and are very deep in terms on functionality.
-* [Geocoding](docs/Geocoding.md) documents how to do simple geocoding, reverse geocoding and batch geocoding.
+* [Feature Services](docs/FeatureServices.md) allow you to interact with feature geometry and attributes from Esri services
+* [Geocoding](docs/Geocoding.md) is turning an address or place name into a location. The documentation describes simple geocoding, reverse geocoding and batch geocoding.
 
 ## Contributing
 
@@ -57,10 +66,9 @@ Esri welcomes contributions from anyone and everyone. Please see our [guidelines
 
 This is an open library for communicating with any service that implements the Geoservices specification.  The default endpoint for Geocoding is ArcGIS Online.  Please see [Terms of Use](http://resources.arcgis.com/en/help/arcgis-rest-api/#/ArcGIS_Online_services_licensing/02r3000001mv000000/) for licensing and usage details.
 
-## See Also ##
+## See Also
 
- * [gecoder-arcgis](https://github.com/StephanGeorg/geocoder-arcgis) provides a client for just the Geocoding APIs with a promise-based design. 
-
+ * [gecoder-arcgis](https://github.com/StephanGeorg/geocoder-arcgis) provides a client for just the Geocoding APIs with a promise-based design.
 
 [](Esri Tags: GeoServices Node.js Node)
 [](Esri Language: JavaScript)

--- a/README.md
+++ b/README.md
@@ -69,6 +69,3 @@ This is an open library for communicating with any service that implements the G
 ## See Also
 
  * [gecoder-arcgis](https://github.com/StephanGeorg/geocoder-arcgis) provides a client for just the Geocoding APIs with a promise-based design.
-
-[](Esri Tags: GeoServices Node.js Node)
-[](Esri Language: JavaScript)

--- a/docs/Geocoding.md
+++ b/docs/Geocoding.md
@@ -15,7 +15,7 @@ documented here are based on that API. For the most current and official informa
 By default, geocoding makes simple single input field requests to the [World Geocoding Service](https://developers.arcgis.com/rest/geocode/api-reference/overview-world-geocoding-service.htm):
 
 ```javascript
-    client.geocode({ text: "920 SW 3rd Ave, Portland, OR 97201" }, function (err, result) {
+    client.geocode({ singleLine: "920 SW 3rd Ave, Portland, OR 97201" }, function (err, result) {
       if (err) {
         console.error("ERROR: " + err);
       } else {
@@ -26,25 +26,24 @@ By default, geocoding makes simple single input field requests to the [World Geo
 ```
 
 `client.geocode` is a shortcut for calling `client.geocode.simple`.
-`text` is mapped automatically as the geocoder parameter `singleLine`.
 
 ## Passing additional parameters
 
-Any parameter supported by the [`findAddressCandidates`](https://developers.arcgis.com/rest/geocode/api-reference/geocoding-find-address-candidates.htm) operation of the World Geocoding Service can be passed through.
+Any other parameter supported by the [`findAddressCandidates`](https://developers.arcgis.com/rest/geocode/api-reference/geocoding-find-address-candidates.htm) operation of the World Geocoding Service can also be passed through.
 
 ```javascript
     client.geocode({
         address: "920 SW 3rd Ave",
-        searchExtent: "-101,30,-100,31"   
+        searchExtent: "-101,30,-100,31"
     }, geocoderResponseCallback);
 ```
 
-You can also send requests to a geocoding service hosted on ArcGIS Server.
+You can also send requests to your own geocoding service hosted on ArcGIS Server.
 
 ```javascript
     client.options.geocoderUrl: "https://yourserver.com/arcgis/rest/services/CustomGeocoder"
     client.geocode({
-        address: "920 SW 3rd Ave"  
+        address: "920 SW 3rd Ave"
     }, geocoderResponseCallback);
 ```
 

--- a/docs/Geocoding.md
+++ b/docs/Geocoding.md
@@ -12,21 +12,42 @@ documented here are based on that API. For the most current and official informa
 
 ## Simple geocoding
 
-By default, geocoding uses simple single input field geocoding:
+By default, geocoding makes simple single input field requests to the [World Geocoding Service](https://developers.arcgis.com/rest/geocode/api-reference/overview-world-geocoding-service.htm):
 
 ```javascript
     client.geocode({ text: "920 SW 3rd Ave, Portland, OR 97201" }, function (err, result) {
       if (err) {
         console.error("ERROR: " + err);
       } else {
-        console.log("Found it at " + result.locations[0].feature.geometry.y
-        + ", " + result.locations[0].feature.geometry.x);
+        console.log("Found it at " + result.candidates[0].location.y
+        + ", " + result.candidates[0].location.geometry.x);
       }
     });
 ```
 
 `client.geocode` is a shortcut for calling `client.geocode.simple`.
-
+`text` is mapped automatically as the geocoder parameter `singleLine`.
+
+## Passing additional parameters
+
+Any parameter supported by the [`findAddressCandidates`](https://developers.arcgis.com/rest/geocode/api-reference/geocoding-find-address-candidates.htm) operation of the World Geocoding Service can be passed through.
+
+```javascript
+    client.geocode({
+        address: "920 SW 3rd Ave",
+        searchExtent: "-101,30,-100,31"   
+    }, geocoderResponseCallback);
+```
+
+You can also send requests to a geocoding service hosted on ArcGIS Server.
+
+```javascript
+    client.options.geocoderUrl: "https://yourserver.com/arcgis/rest/services/CustomGeocoder"
+    client.geocode({
+        address: "920 SW 3rd Ave"  
+    }, geocoderResponseCallback);
+```
+
 ## Reverse Geocoding
 
 ```javascript

--- a/lib/geocode.js
+++ b/lib/geocode.js
@@ -56,16 +56,17 @@ function geocode (parameters, callback) {
     parameters.f = 'json';
   }
 
+  // allow a text query like simple geocode service to return all candidate addresses
+  if (parameters.text) {
+    parameters.singleLine = parameters.text;
+    delete parameters.text;
+  }
+
   // build the request url
   var url = baseUrl(this.options);
 
   url += '/findAddressCandidates?';
 
-  // allow a text query like simple geocode service to return all candidate addresses
-  if (parameters.text) {
-    parameters.SingleLine = parameters.text;
-    delete parameters.text;
-  }
   // at very least you need the Addr_type attribute returned with results
   if (!parameters.outFields) {
     parameters.outFields = "Addr_type";

--- a/lib/geocode.js
+++ b/lib/geocode.js
@@ -2,7 +2,6 @@ var querystring = require('querystring');
 var request = require('request');
 var stringify = querystring.stringify;
 
-
 /**
  * @module Geostore
 */
@@ -53,11 +52,30 @@ function _handleArcGISResponse (error, response, body, callback) {
  * geoservice.geocode({ text: "920 SW 3rd Ave, Portland, OR 97204" }, callback);
 */
 function geocode (parameters, callback) {
-  parameters.f = parameters.f || "json";
+  if (!parameters.f) {
+    parameters.f = 'json';
+  }
 
   // build the request url
   var url = baseUrl(this.options);
-  url += '/find?';
+
+  url += '/findAddressCandidates?';
+
+  // allow a text query like simple geocode service to return all candidate addresses
+  if (parameters.text) {
+    parameters.SingleLine = parameters.text;
+    delete parameters.text;
+  }
+  // at very least you need the Addr_type attribute returned with results
+  if (!parameters.outFields) {
+    parameters.outFields = "Addr_type";
+  }
+
+  if (parameters.outFields !== '*' &&
+    parameters.outFields.indexOf('Addr_type') < 0) {
+    parameters.outFields += ',Addr_type';
+  }
+
   url += stringify(parameters);
 
   request.get(url, function (error, response, body) {
@@ -77,38 +95,6 @@ function reverse (parameters, callback) {
   var url = baseUrl(this.options);
 
   url += '/reverseGeocode?';
-  url += stringify(parameters);
-
-  request.get(url, function (error, response, body) {
-    return _handleArcGISResponse(error, response, body, callback);
-  });
-}
-
-function addresses (parameters, callback) {
-  if (!parameters.f) {
-    parameters.f = 'json';
-  }
-
-  //build the request url
-  var url = baseUrl(this.options);
-
-  url += '/findAddressCandidates?';
-
-  //allow a text query like simple geocode service to return all candidate addresses
-  if (parameters.text) {
-    parameters.SingleLine = parameters.text;
-    delete parameters.text;
-  }
-  //at very least you need the Addr_type attribute returned with results
-  if (!parameters.outFields) {
-    parameters.outFields = "Addr_type";
-  }
-
-  if (parameters.outFields !== '*' &&
-    parameters.outFields.indexOf('Addr_type') < 0) {
-    parameters.outFields += ',Addr_type';
-  }
-
   url += stringify(parameters);
 
   request.get(url, function (error, response, body) {
@@ -175,6 +161,5 @@ Batch.prototype.run = function (callback) {
 
 geocode.simple  = geocode;
 geocode.reverse = reverse;
-geocode.addresses = addresses;
 exports.Batch   = Batch;
 exports.geocode = geocode;

--- a/test/geocode-test.js
+++ b/test/geocode-test.js
@@ -7,24 +7,28 @@ var geocode = require('../lib/geocode');
 vows.describe('Geocode').addBatch({
   'When requesting a valid geocode': {
     topic: function () {
-      geocode.geocode({ text: "920 SW 3rd Ave, Portland, OR 97204" }, this.callback);
+      geocode.geocode({ 
+        text: "920 SW 3rd Ave, Portland, OR 97204"
+      }, this.callback);
     },
     'It should return the correct latitude and longitude': function (err, data) {
       assert.equal(err, null);
-      assert.equal(data.locations.length, 1);
-      assert.equal(data.locations[0].feature.geometry.x.toPrecision(5), (-122.67633658436517).toPrecision(5));
-      assert.equal(data.locations[0].feature.geometry.y.toPrecision(5), (45.5167324388521).toPrecision(5));
+      assert.isTrue(data.candidates.length > 1);
+      assert.equal(data.candidates[0].location.x.toPrecision(5), (-122.67633658436517).toPrecision(5));
+      assert.equal(data.candidates[0].location.y.toPrecision(5), (45.5167324388521).toPrecision(5));
     }
   },
   'When running using the "simple" method': {
     topic: function () {
-      geocode.geocode.simple({ text: "920 SW 3rd Ave, Portland, OR 97204" }, this.callback);
+      geocode.geocode.simple({ 
+        text: "920 SW 3rd Ave, Portland, OR 97204"
+      }, this.callback);
     },
     'It should return the correct latitude and longitude': function (err, data) {
       assert.equal(err, null);
-      assert.equal(data.locations.length, 1);
-      assert.equal(data.locations[0].feature.geometry.x.toPrecision(5), (-122.67633658436517).toPrecision(5));
-      assert.equal(data.locations[0].feature.geometry.y.toPrecision(5), (45.5167324388521).toPrecision(5));
+      assert.isTrue(data.candidates.length > 1);
+      assert.equal(data.candidates[0].location.x.toPrecision(5), (-122.67633658436517).toPrecision(5));
+      assert.equal(data.candidates[0].location.y.toPrecision(5), (45.5167324388521).toPrecision(5));
     }
   },
   'When using reverse geocoding': {
@@ -47,7 +51,7 @@ vows.describe('Geocode').addBatch({
   },
   'When requesting all address matches using text': {
     topic: function () {
-      geocode.geocode.addresses({ text: "920 3rd Ave, Portland, OR 97204" }, this.callback);
+      geocode.geocode({ text: "920 3rd Ave, Portland, OR 97204" }, this.callback);
     },
     'It should return a sorted list of likely geocode matches': function (err, data) {
       assert.equal(err, null);
@@ -60,7 +64,7 @@ vows.describe('Geocode').addBatch({
   },
   'When requesting all address matches using object': {
     topic: function () {
-      geocode.geocode.addresses({
+      geocode.geocode({
         Address: "920 3rd Ave",
         City: "Portland",
         Region: "OR",

--- a/test/geocode-test.js
+++ b/test/geocode-test.js
@@ -7,8 +7,8 @@ var geocode = require('../lib/geocode');
 vows.describe('Geocode').addBatch({
   'When requesting a valid geocode': {
     topic: function () {
-      geocode.geocode({ 
-        text: "920 SW 3rd Ave, Portland, OR 97204"
+      geocode.geocode({
+        singleLine: "920 SW 3rd Ave, Portland, OR 97204"
       }, this.callback);
     },
     'It should return the correct latitude and longitude': function (err, data) {
@@ -20,8 +20,8 @@ vows.describe('Geocode').addBatch({
   },
   'When running using the "simple" method': {
     topic: function () {
-      geocode.geocode.simple({ 
-        text: "920 SW 3rd Ave, Portland, OR 97204"
+      geocode.geocode.simple({
+        singleLine: "920 SW 3rd Ave, Portland, OR 97204"
       }, this.callback);
     },
     'It should return the correct latitude and longitude': function (err, data) {
@@ -49,9 +49,9 @@ vows.describe('Geocode').addBatch({
       assert.equal(err.message, "Unable to complete operation.");
     }
   },
-  'When requesting all address matches using text': {
+  'When requesting all address matches using singleLine': {
     topic: function () {
-      geocode.geocode({ text: "920 3rd Ave, Portland, OR 97204" }, this.callback);
+      geocode.geocode({ singleLine: "920 3rd Ave, Portland, OR 97204" }, this.callback);
     },
     'It should return a sorted list of likely geocode matches': function (err, data) {
       assert.equal(err, null);
@@ -113,7 +113,7 @@ vows.describe('Geocode').addBatch({
   'When making an invalid simple request': {
     topic: function () {
       geocode.options = {geocoderUrl: "http://geocode.arcgis.com/arcgis/rest/services/foo"};
-      geocode.geocode({ text: "920 SW 3rd Ave, Portland, OR 97204" }, this.callback);
+      geocode.geocode({ singleLine: "920 SW 3rd Ave, Portland, OR 97204" }, this.callback);
       geocode.options = null;
     },
     'we should parse the response manually for the error within the 200 status code message': function (err, data) {
@@ -125,7 +125,7 @@ vows.describe('Geocode').addBatch({
   'When making a really invalid simple request': {
     topic: function () {
       geocode.options = {geocoderUrl: "http://foo.arcgis.com/arcgis/rest/services/GeocodeServer"};
-      geocode.geocode({ text: "920 SW 3rd Ave, Portland, OR 97204" }, this.callback);
+      geocode.geocode({ singleLine: "920 SW 3rd Ave, Portland, OR 97204" }, this.callback);
       geocode.options = null;
     },
     'we should return the genuine error response from the server': function (err, data) {

--- a/test/integration-test.js
+++ b/test/integration-test.js
@@ -7,7 +7,7 @@ vows.describe('Integration').addBatch({
   'When requesting a valid geocode': {
     topic: function () {
       var esri = new geoservices();
-      esri.geocode({ text: "920 SW 3rd Ave, Portland, OR 97204" }, this.callback);
+      esri.geocode({ singleLine: "920 SW 3rd Ave, Portland, OR 97204" }, this.callback);
     },
     'It should return the correct latitude and longitude': function (err, data) {
       assert.equal(err, null);

--- a/test/integration-test.js
+++ b/test/integration-test.js
@@ -11,9 +11,9 @@ vows.describe('Integration').addBatch({
     },
     'It should return the correct latitude and longitude': function (err, data) {
       assert.equal(err, null);
-      assert.equal(data.locations.length, 1);
-      assert.equal(data.locations[0].feature.geometry.x.toPrecision(7), (-122.67645787323158).toPrecision(7));
-      assert.equal(data.locations[0].feature.geometry.y.toPrecision(7), (45.51650314320659).toPrecision(7));
+      assert.equal(data.candidates.length, 10);
+      assert.equal(data.candidates[0].location.x.toPrecision(7), (-122.67645787323158).toPrecision(7));
+      assert.equal(data.candidates[0].location.y.toPrecision(7), (45.51650314320659).toPrecision(7));
     }
   }
 }).export(module);


### PR DESCRIPTION
resolves #107

this change makes consistent use of the findAddressCandidates operation of the World Geocoding Service.  this makes it unnecessary to differentiate and maintain simple() and addresses() methods for geocoding.

wrote out a few more samples in the markdown doc to demonstrate how to pass additional parameters and make requests to custom services.

because the response signature of findAddressCandidates differs from find, it seemed like a good time to group some additional cleanup and just call the whole thing a breaking change.